### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Music Synthesizer for Android #
 ## Getting Started ##
-The following steps will get you started with Music Synthesizer for Android code in a Unix-like environment.  Read each step carefully.  Also check out the [notes section](#Notes) for further details on the project. The following environment variables are used:
+The following steps will get you started with Music Synthesizer for Android code in a Unix-like environment.  Read each step carefully.  Also check out the [notes section](#notes) for further details on the project. The following environment variables are used:
   * `SYNTH_PATH` - The folder which contains the Music Synthesizer source code.
   * `PROTO_PATH` - The folder which contains the Protocol Buffers.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following is a list of IDEs, SDKs, libraries, other necessary software.  Dow
 1.  The [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html). (JDK7 recommended)
 2.  One of the following IDEs running the newest Android API.
 
-    - [Eclipse for Java Developers](https://eclipse.org/downloads/packages/) with the [Android Standard Development Kit Tools](https://developer.android.com/sdk/index.html#Other).
+    - [Eclipse for Java Developers](https://eclipse.org/downloads/packages/) with the [Android SDK Tools](https://developer.android.com/sdk/index.html#Other) and [Android Development Tools Plugin](http://developer.android.com/sdk/installing/installing-adt.html).
     - [Android Studio](https://developer.android.com/sdk/installing/index.html?pkg=studio) (Not yet fully supported by this project.)
 
 3.  The [Android Native-Code Development Kit (NDK)](https://developer.android.com/ndk).  _Tip:_ If you extract it to `$HOME/android-ndk` (leaving out the version number) a future step will be easier.
@@ -65,7 +65,7 @@ Copy the binary and runtime library to the project folder by running the followi
 ```
 mkdir $SYNTH_PATH/core/bin $SYNTH_PATH/core/lib
 cp $PROTO_PATH/bin/protoc $SYNTH_PATH/core/bin/
-cp $PROTO_PATH/java/target/protobuf-java.jar $SYNTH_PATH/core/lib/libprotobuf.jar
+cp $PROTO_PATH/java/target/protobuf-java-*.jar $SYNTH_PATH/core/lib/libprotobuf.jar
 ```
 
 ## Test Core Components ##

--- a/README.md
+++ b/README.md
@@ -1,114 +1,84 @@
-# Getting Started with Music Synthesizer for Android #
-
-The following steps will get you started working with the Music Synthesizer for Android code in a Unix-like environment. The following environment variables are used:
+# Music Synthesizer for Android #
+## Getting Started ##
+The following steps will get you started with Music Synthesizer for Android code in a Unix-like environment.  Read each step carefully.  Also check out the [notes section](#Notes) for further details on the project. The following environment variables are used:
   * `SYNTH_PATH` - The folder which contains the Music Synthesizer source code.
   * `PROTO_PATH` - The folder which contains the Protocol Buffers.
 
-## IDEs, SDKs, Libraries, & Other Necessary Software ##
-Please download and set up the Java & Android IDE & SDKs if you have not done so already.
+## Downloads ##
+The following is a list of IDEs, SDKs, libraries, other necessary software.
 
-1.  [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html) (JDK7 recommended)
-2.  An IDE: (One of the following)
-  - [Eclipse for Java Developers](https://eclipse.org/downloads/packages/) with the [Android Standard Development Kit Tools](https://developer.android.com/sdk/index.html#Other)  (Newest API recommended)
-  - [Android Studio](https://developer.android.com/sdk/installing/index.html?pkg=studio)  _Note:_ Android Studio is not yet supported by this project. However, the core, test, and j2se packages can be built using Ant. So the desktop tools in the j2se package can still be built without Eclipse.   (Newest API recommended)
-3.  The [Android Native-Code Development Kit (NDK)](https://developer.android.com/ndk)
+1.  The [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html). (JDK7 recommended)
+2.  One of the following IDEs running the newest Android API.
 
-  The synthesizer engine is written in C++ for higher performance, and uses OpenSL ES to output sound.
+    - [Eclipse for Java Developers](https://eclipse.org/downloads/packages/) with the [Android Standard Development Kit Tools](https://developer.android.com/sdk/index.html#Other).
+    - [Android Studio](https://developer.android.com/sdk/installing/index.html?pkg=studio) (Not yet fully supported by this project.)
+
+3.  The [Android Native-Code Development Kit (NDK)](https://developer.android.com/ndk).  _Tip:_ If you extract it to `$HOME/android-ndk` (leaving out the version number) a future step will be easier.
   
-  _Tip:_ If you save the NDK to `$HOME/android-ndk` (leaving out the version number) a future step will be easier.
+4. The [Google Protocol Buffers](https://developers.google.com/protocol-buffers/docs/downloads). _Tip:_ If you extract it to `$HOME/protobuf` (leaving out the version number) a future step will be easier.
 
-4.  Debian (Ubuntu) Only
+5.  Debian (Ubuntu) Only
 
-    With elevated privileges (`sudo`) run the following commands to download & install necessary software & libraries:
+    With elevated privileges (`sudo`) run the following commands to download and install necessary software and libraries:
 
         dpkg --add-architecture i386
         apt-get update
         apt-get install lib32z1 libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 g++ maven default-jre default-jdk
 
 ## Clone the Code ##
-Using Git, clone the Music Synthesizer for Android source code:
+Using Git, clone the Music Synthesizer for Android source code and set your `SYNTH_PATH` variable:
 
+    cd $HOME
     git clone https://github.com/matthewcordaro/music-synthesizer-for-android.git
-    
-Set your `SYNTH_PATH` variable.  Example:
-
     export SYNTH_PATH=$HOME/music-synthesizer-for-android
 
-## Download & Install Protocol Buffers ##
-[Download](https://developers.google.com/protocol-buffers/docs/downloads) the Google Protocol Buffers. An overview can be found [here](https://developers.google.com/protocol-buffers/docs/overview).
+## Make the Protocol Buffers - Debian (Ubuntu) Only ##
+1. Extract the buffers:
+    ```
+    tar -xzvf protobuf-*.tar.gz -C $HOME/protobuf
+    ```
 
+2. Set your `PROTO_PATH` variable. Example:
+    ```
+    export PROTO_PATH=$HOME/protobuf
+    ```
+
+3. Build the protocol buffer binary by running the following commands:
+
+    cd $PROTO_PATH
+    ./configure --prefix=$PROTO_PATH
+    make
+    make check
+    make install
+
+4. Build the protocol buffer runtime library by running the following commands:
+
+    cd $PROTO_PATH/java
+    mvn test
+    mvn install
+    mvn package
+
+## Install the Protocol Buffers ##
 ### Windows ###
 Install the pre built Windows `protoc` compiler in `$SYNTH_PATH/core/bin`.
 
-Set your `PROTO_PATH` variable. Example:
-<pre>
-export PROTO_PATH=$HOME/protobuf-<b>{VERSION}</b>
-</pre>
-
 ### Debian (Ubuntu) ###
-1. Extract the buffers:
-  ```
-  tar -xzvf protobuf-*.tar.gz
-  ```
-
-2. Set your `PROTO_PATH` variable. Example:
-  <pre>
-  export PROTO_PATH=$HOME/protobuf-<b>{VERSION}</b>
-  </pre>
-
-3. Build the protocol buffer binary by running the following commands:
-  ```
-  cd $PROTO_PATH
-  ./configure --prefix=$PROTO_PATH
-  make
-  make check
-  make install
-  ```
-
-4. Build the protocol buffer runtime library by running the following commands:
-  ```
-  cd $PROTO_PATH/java
-  mvn test
-  mvn install
-  mvn package
-  ```
-
-5. Copy the binary and runtime library to the project folder by running the following commands:
-  <pre>
+Copy the binary and runtime library to the project folder by running the following commands:
+```
   mkdir $SYNTH_PATH/core/bin $SYNTH_PATH/core/lib
   cp $PROTO_PATH/bin/protoc $SYNTH_PATH/core/bin/
-  cp $PROTO_PATH/java/target/protobuf-java-<b>{VERSION}</b>.jar $SYNTH_PATH/core/lib/libprotobuf.jar
-  </pre>
+  cp $PROTO_PATH/java/target/protobuf-java.jar $SYNTH_PATH/core/lib/libprotobuf.jar
+```
 
 ## Test Core Components ##
-To make sure everything so far is installed correctly, run the tests and make sure they all build and pass.
+To make sure everything is installed correctly so far, run the ant tests.  If they do not all pass, verify that you have done the above steps properly.
 ```
 cd $SYNTH_PATH
 ant test
 ```
 
-### Compiling the Synthesizer Engine ###
-The result of this step is the `libsynth.so` files found in `$SYNTH_PATH/android/libs/*/` which contain any shared libraries.  A NDK build depends on the target architecture (unlike Java code). It can be changed by editing `APP\_ABI` in the `$SYNTH_PATH/android/jni/Application.mk` file. We have defaulted `APP\_ABI` to `all` so that it will run on all possible devices. However, this is at the expense of slowing the compile cycle and increasing the APK file size. If you are routinely editing code for a single device, you may want to change this to the proper architecture. See [here](https://developer.android.com/ndk/guides/arch.html) for more information. _Note:_ Code built for `armeabi` will run on _ARM v7_ devices, but more slowly.  
-
-You can either manually run the NDK compile, or set up your Eclipse project to run it automatically:
-  - For Manual Building 
-
-    Make sure that NDK folder is in your `PATH` variable and run:
-
-        cd $SYNTH_PATH/android
-        ndk-build
-
-  - For Integrated Eclipse Building 
-
-    If your NDK is saved to `$HOME/android-ndk` then Eclipse will automaticall work and you can skip this step. Otherwise, edit `$SYNTH_PATH/android/.externalToolBuilders/NDK Builder.launch` to make sure that `ATTR\_LOCATION` points to a valid location for the ndk-build binary. Example:
-    <pre>
-    ${HOME}/android-ndk-<b>{VERSION}</b>/ndk-build
-    </pre>
-
-_Tip:_ If you run into any errors, try `ndk-build clean` then `ndk-build` before searching for a fix.
-
 ## Make the Environment Variables Persistent ##
-You will probably want to add the `SYNTH_PATH` & `PROTO_PATH` environment variables to the OS so life is easier after a reboot. (You may want to include both the NDK and SDK Tools on your `PATH` as well.)
+You will probably want to add the `SYNTH_PATH` and `PROTO_PATH` environment variables to the OS so life is a little easier. You may want to include both the NDK and SDK Tools on your `PATH` as well.
 
 ### Windows ###
 1.  Goto Control Panel > System and Security > System.
@@ -119,10 +89,26 @@ You will probably want to add the `SYNTH_PATH` & `PROTO_PATH` environment variab
 ### Debian (Ubuntu) ###
 Append the `export X_PATH=path/to/something` to the end of your `~/.profile`, `/etc/profile`, or `/etc/environment` depending on your preference.
 
+## Compile the Synthesizer Engine ##
+Now we use the NDK to build the shared libraries. (`libsynth.so` files that will be found in `$SYNTH_PATH/android/libs/*/`.)  You can either manually run the NDK compile, or have your Eclipse project run it automatically.
+  - For automatic Eclipse building, if your NDK is saved to `$HOME/android-ndk` then Eclipse should automatically work and you can skip this step. Otherwise, edit `$SYNTH_PATH/android/.externalToolBuilders/NDK Builder.launch` to make sure that `ATTR\_LOCATION` points to a valid location for the ndk-build binary, such as `${HOME}/android-ndk/ndk-build`.
+
+  - For manual building, make sure that the NDK folder is in your `PATH` variable and run:
+    ```
+    cd $SYNTH_PATH/android
+    ndk-build
+    ```
+
+_Tip:_ If you run into any errors, try `ndk-build clean` then `ndk-build` before searching for a fix.
+
 ## Setting up Music Synthesizer in Eclipse ##
 1. Make a new workspace.
 2. Import the project. _File > Import > Android > Existing Android Code Into Workspace_. Follow on-screen instructions.
 
-_Note:_ You will probably get errors on import (duplicate entry 'src', empty ${project\_loc}, and maybe others). You can ignore these (although it would be great to clean them up).
-
 _Tip:_ If you receive many errors that state "X cannot be resolved to a type" then it is likely your NDK generated Java files are not linked properly. Go to _Project > Properties > Resource > Linked Resources_ and click on Linked Resources tab. Finally edit the core-gen variable to point to `PROJECT_LOC/core-gen` or similar.
+
+##  Notes ##
+- The synthesizer engine is written in C++ for performance, and uses OpenSL ES to output sound.
+-  A NDK build depends on the target architecture (unlike Java code). It can be changed by editing `APP\_ABI` in the `$SYNTH_PATH/android/jni/Application.mk` file. We have defaulted `APP\_ABI` to `all` so that it will run on all possible devices. However, this slows the compile cycle and increases the APK file size. If you are routinely editing code for a single device, you may want to change this to the proper architecture. See [here](https://developer.android.com/ndk/guides/arch.html) for more information. _Note:_ Code built for `armeabi` will run on _ARM v7_ devices, but more slowly.
+-  The core, test, and j2se packages can be built using Ant. So the desktop tools in the j2se package can still be built without an IDE.
+-  In Eclipse you will probably get errors on import (duplicate entry 'src', empty ${project\_loc}, and maybe others). You can ignore these (although it would be great to clean them up).

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Append the `export X_PATH=path/to/something` to the end of your `~/.profile`, `/
 
 ## Compile the Synthesizer Engine ##
 Now we use the NDK to build the shared libraries. (`libsynth.so` files that will be found in `$SYNTH_PATH/android/libs/*/`.)  You can either manually run the NDK compile, or have your Eclipse project run it automatically.
-  - For automatic Eclipse building, if your NDK is saved to `$HOME/android-ndk` then Eclipse should automatically work and you can skip this step. Otherwise, edit `$SYNTH_PATH/android/.externalToolBuilders/NDK Builder.launch` to make sure that `ATTR\_LOCATION` points to a valid location for the ndk-build binary, such as `${HOME}/android-ndk/ndk-build`.
-
   - For manual building, make sure that the NDK folder is in your `PATH` variable and run:
     ```
     cd $SYNTH_PATH/android
     ndk-build
     ```
+
+  - For automatic Eclipse building, first run the manual build.  Then, if your NDK is saved to `$HOME/android-ndk`, Eclipse should automatically work and you can skip this step. Otherwise, edit `$SYNTH_PATH/android/.externalToolBuilders/NDK Builder.launch` to make sure that `ATTR\_LOCATION` points to a valid location for the ndk-build binary, such as `${HOME}/android-ndk/ndk-build`.
 
 _Tip:_ If you run into any errors, try `ndk-build clean` then `ndk-build` before searching for a fix.
 
@@ -103,7 +103,7 @@ _Tip:_ If you run into any errors, try `ndk-build clean` then `ndk-build` before
 1. Make a new workspace.
 2. Import the project. _File > Import > Android > Existing Android Code Into Workspace_. Follow on-screen instructions.
 
-_Tip:_ If you receive many errors that state "X cannot be resolved to a type" then it is likely your NDK generated Java files are not linked properly. Go to _Project > Properties > Resource > Linked Resources_ and click on Linked Resources tab. Finally edit the core-gen variable to point to `PROJECT_LOC/core-gen` or similar.
+_Tip:_ If you receive many errors that state "X cannot be resolved to a type" then it is likely your NDK generated Java files are not linked properly. Go to _Project > Properties > Resource > Linked Resources_ and click on Linked Resources tab. Finally edit the core-gen variable to point to `PROJECT_LOC/core-gen` or similar.  This may not solve the issue; you may need to manually build the NDK code.
 
 ##  Notes ##
 - The synthesizer engine is written in C++ for performance, and uses OpenSL ES to output sound.

--- a/README.md
+++ b/README.md
@@ -44,19 +44,21 @@ Using Git, clone the Music Synthesizer for Android source code and set your `SYN
     ```
 
 3. Build the protocol buffer binary by running the following commands:
-
+    ```
     cd $PROTO_PATH
     ./configure --prefix=$PROTO_PATH
     make
     make check
     make install
+    ```
 
 4. Build the protocol buffer runtime library by running the following commands:
-
+    ```
     cd $PROTO_PATH/java
     mvn test
     mvn install
     mvn package
+    ```
 
 ## Install the Protocol Buffers ##
 ### Windows ###
@@ -65,9 +67,9 @@ Install the pre built Windows `protoc` compiler in `$SYNTH_PATH/core/bin`.
 ### Debian (Ubuntu) ###
 Copy the binary and runtime library to the project folder by running the following commands:
 ```
-  mkdir $SYNTH_PATH/core/bin $SYNTH_PATH/core/lib
-  cp $PROTO_PATH/bin/protoc $SYNTH_PATH/core/bin/
-  cp $PROTO_PATH/java/target/protobuf-java.jar $SYNTH_PATH/core/lib/libprotobuf.jar
+mkdir $SYNTH_PATH/core/bin $SYNTH_PATH/core/lib
+cp $PROTO_PATH/bin/protoc $SYNTH_PATH/core/bin/
+cp $PROTO_PATH/java/target/protobuf-java.jar $SYNTH_PATH/core/lib/libprotobuf.jar
 ```
 
 ## Test Core Components ##

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The following steps will get you started with Music Synthesizer for Android code
   * `PROTO_PATH` - The folder which contains the Protocol Buffers.
 
 ## Downloads ##
-The following is a list of IDEs, SDKs, libraries, other necessary software.
+The following is a list of IDEs, SDKs, libraries, other necessary software.  Download and extract them.
 
 1.  The [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html). (JDK7 recommended)
 2.  One of the following IDEs running the newest Android API.
@@ -19,11 +19,11 @@ The following is a list of IDEs, SDKs, libraries, other necessary software.
 
 5.  Debian (Ubuntu) Only
 
-    With elevated privileges (`sudo`) run the following commands to download and install necessary software and libraries:
+    Run the following commands to download and install necessary software and libraries:
 
-        dpkg --add-architecture i386
-        apt-get update
-        apt-get install lib32z1 libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 g++ maven default-jre default-jdk
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install git lib32z1 libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 g++ maven default-jre default-jdk
 
 ## Clone the Code ##
 Using Git, clone the Music Synthesizer for Android source code and set your `SYNTH_PATH` variable:
@@ -33,17 +33,13 @@ Using Git, clone the Music Synthesizer for Android source code and set your `SYN
     export SYNTH_PATH=$HOME/music-synthesizer-for-android
 
 ## Make the Protocol Buffers - Debian (Ubuntu) Only ##
-1. Extract the buffers:
-    ```
-    tar -xzvf protobuf-*.tar.gz -C $HOME/protobuf
-    ```
 
-2. Set your `PROTO_PATH` variable. Example:
+1. Set your `PROTO_PATH` variable. Example:
     ```
     export PROTO_PATH=$HOME/protobuf
     ```
 
-3. Build the protocol buffer binary by running the following commands:
+2. Build the protocol buffer binary by running the following commands:
     ```
     cd $PROTO_PATH
     ./configure --prefix=$PROTO_PATH
@@ -52,7 +48,7 @@ Using Git, clone the Music Synthesizer for Android source code and set your `SYN
     make install
     ```
 
-4. Build the protocol buffer runtime library by running the following commands:
+3. Build the protocol buffer runtime library by running the following commands:
     ```
     cd $PROTO_PATH/java
     mvn test


### PR DESCRIPTION
A retooling of the instructions with the goal of making it leaner and more precise.
All downloads are listed in a 'downloads' section.
Notes and other "non essential" information have moved into a 'notes' section at the bottom.
Removed the need for NDK and protobuf version numbers.
Offers new solutions to some issues.
